### PR TITLE
Dict support for python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2025-09-09
+
+### Added
+- Bash associative arrays support via `envsh-utils.sh`
+- `export_array_as_json` function for converting associative arrays to JSON
+- Support for reading dictionary structures with `read_env(..., dict)` 
+- Variable interpolation within associative array values
+- Complex configuration profiles using structured data
+- Enhanced shell utilities for better configuration management
+- Examples demonstrating structured configuration usage
+
+### Enhanced
+- Shell environment loading now includes utility functions
+- Improved documentation with structured configuration examples
+
 ## [0.1.1] - 2025-08-27
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ install-dev:
 	poetry install --with dev
 
 test:
-	poetry run pytest tests/ -v
+	poetry run pytest tests/ -v -s
 
 lint:
-	ruff check --fix .
-	mypy src tests
+	poetry run ruff check --fix .
+	poetry run mypy src tests
 
 clean:
 	rm -rf build/

--- a/examples/env.sh
+++ b/examples/env.sh
@@ -3,12 +3,53 @@
 # Test environment variables for envsh library
 # Demonstrating variable interpolation - the main advantage over .env files
 
+# Base configuration
 export BASE_PORT=8000
 export HOST="localhost"
 export DB_NAME="myapp"
+export DB_USER="admin"
+export DB_PASSWORD="secret123"
+
+# Database configuration profile
+declare -A DB_CONFIG=(
+    [HOST]="$HOST"
+    [PORT]="5432"
+    [NAME]="$DB_NAME"
+    [USER]="$DB_USER"
+    [PASSWORD]="$DB_PASSWORD"
+    [SSL_MODE]="prefer"
+    [POOL_SIZE]="10"
+    [TIMEOUT]="30"
+)
+export_array_as_json DB_CONFIG 2>/dev/null || true
+
+# MQTT configuration profile
+declare -A MQTT_CONFIG=(
+    [HOST]="$HOST"
+    [PORT]="1883"
+    [USERNAME]="mqtt_user"
+    [PASSWORD]="mqtt_pass"
+    [TOPIC_PREFIX]="$APP_NAME"
+    [QOS]="1"
+    [KEEP_ALIVE]="60"
+)
+export_array_as_json MQTT_CONFIG 2>/dev/null || true
+
+# Redis configuration profile
+declare -A REDIS_CONFIG=(
+    [HOST]="$HOST"
+    [PORT]="6379"
+    [PASSWORD]=""
+    [DATABASE]="0"
+    [POOL_SIZE]="5"
+)
+export_array_as_json REDIS_CONFIG 2>/dev/null || true
 
 # Variable interpolation - this is what makes envsh special!
-export DATABASE_URL="postgresql://$HOST:5432/$DB_NAME"
+export DATABASE_URL="postgresql://${DB_CONFIG[USER]}:${DB_CONFIG[PASSWORD]}@${DB_CONFIG[HOST]}:${DB_CONFIG[PORT]}/${DB_CONFIG[NAME]}"
+export REDIS_URL="redis://${REDIS_CONFIG[HOST]}:${REDIS_CONFIG[PORT]}/${REDIS_CONFIG[DATABASE]}"
+export MQTT_URL="mqtt://${MQTT_CONFIG[USERNAME]}:${MQTT_CONFIG[PASSWORD]}@${MQTT_CONFIG[HOST]}:${MQTT_CONFIG[PORT]}"
+
 export API_ENDPOINT="http://$HOST:$BASE_PORT/api"
 export WORKER_PORTS="$BASE_PORT,$(($BASE_PORT + 1)),$(($BASE_PORT + 2))"
 

--- a/examples/scr/basic_usage.py
+++ b/examples/scr/basic_usage.py
@@ -23,13 +23,66 @@ print(f"BASE_PORT: {base_port}")
 print(f"HOST: {host}")
 print(f"DB_NAME: {db_name}")
 
+print("\n=== Configuration Structures (JSON from Bash Associative Arrays) ===")
+# Read configuration structures exported as JSON
+db_config = envsh.read_env('DB_CONFIG_JSON', dict)
+mqtt_config = envsh.read_env('MQTT_CONFIG_JSON', dict)
+redis_config = envsh.read_env('REDIS_CONFIG_JSON', dict)
+
+print(f"DB_CONFIG: {db_config}")
+print("  -> Host:", db_config['HOST'])
+print("  -> Port:", db_config['PORT'])
+print("  -> Database:", db_config['NAME'])
+print("  -> Pool Size:", db_config['POOL_SIZE'])
+
+print(f"\nMQTT_CONFIG: {mqtt_config}")
+print("  -> Host:", mqtt_config['HOST'])
+print("  -> Port:", mqtt_config['PORT'])
+print("  -> Username:", mqtt_config['USERNAME'])
+print("  -> Topic Prefix:", mqtt_config.get('TOPIC_PREFIX', 'N/A'))
+
+print(f"\nREDIS_CONFIG: {redis_config}")
+print("  -> Host:", redis_config['HOST'])
+print("  -> Port:", redis_config['PORT'])
+print("  -> Database:", redis_config['DATABASE'])
+print("  -> Pool Size:", redis_config['POOL_SIZE'])
+
+print("\n=== Using Configuration Structures ===")
+# Demonstrate practical usage of configuration structures
+def create_database_connection_string(config):
+    """Create database connection string from config structure."""
+    return f"postgresql://{config['USER']}:{config['PASSWORD']}@{config['HOST']}:{config['PORT']}/{config['NAME']}?sslmode={config['SSL_MODE']}"
+
+def create_redis_connection_string(config):
+    """Create Redis connection string from config structure."""
+    password_part = f":{config['PASSWORD']}@" if config['PASSWORD'] else ""
+    return f"redis://{password_part}{config['HOST']}:{config['PORT']}/{config['DATABASE']}"
+
+def create_mqtt_connection_string(config):
+    """Create MQTT connection string from config structure."""
+    return f"mqtt://{config['USERNAME']}:{config['PASSWORD']}@{config['HOST']}:{config['PORT']}"
+
+db_conn_str = create_database_connection_string(db_config)
+redis_conn_str = create_redis_connection_string(redis_config)
+mqtt_conn_str = create_mqtt_connection_string(mqtt_config)
+
+print(f"Database Connection: {db_conn_str}")
+print(f"Redis Connection: {redis_conn_str}")
+print(f"MQTT Connection: {mqtt_conn_str}")
+
 print("\n=== Interpolated Variables ===")
 # These values were created using shell variable interpolation
 database_url = envsh.read_env('DATABASE_URL', str)
+redis_url = envsh.read_env('REDIS_URL', str)
+mqtt_url = envsh.read_env('MQTT_URL', str)
 api_endpoint = envsh.read_env('API_ENDPOINT', str)
 
 print(f"DATABASE_URL: {database_url}")
-print("  -> Built from: postgresql://$HOST:5432/$DB_NAME")
+print("  -> Built from: postgresql://${DB_CONFIG[USER]}:${DB_CONFIG[PASSWORD]}@${DB_CONFIG[HOST]}:${DB_CONFIG[PORT]}/${DB_CONFIG[NAME]}")
+print(f"REDIS_URL: {redis_url}")
+print("  -> Built from: redis://${REDIS_CONFIG[HOST]}:${REDIS_CONFIG[PORT]}/${REDIS_CONFIG[DATABASE]}")
+print(f"MQTT_URL: {mqtt_url}")
+print("  -> Built from: mqtt://${MQTT_CONFIG[USERNAME]}:${MQTT_CONFIG[PASSWORD]}@${MQTT_CONFIG[HOST]}:${MQTT_CONFIG[PORT]}")
 print(f"API_ENDPOINT: {api_endpoint}")
 print("  -> Built from: http://$HOST:$BASE_PORT/api")
 
@@ -57,23 +110,44 @@ print("  -> Mixed interpolation with different protocols")
 print(f"PORT_RANGE: {port_range}")
 print("  -> Port calculations: $BASE_PORT,$(($BASE_PORT + 100)),$(($BASE_PORT + 200))")
 
-print("\n=== Why this matters ===")
-print("❌ Standard .env files can't do this:")
-print("   DATABASE_URL=postgresql://$HOST:5432/$DB_NAME  # Won't work!")
-print("   WORKER_PORTS=$BASE_PORT,8001,8002              # Won't work!")
+print("\n=== Configuration Management Examples ===")
+# Demonstrate how to use structures for configuration management
+print("🔧 Database Configuration Management:")
+print(f"  - Connection Pool: {db_config['POOL_SIZE']} connections")
+print(f"  - Connection Timeout: {db_config['TIMEOUT']} seconds")
+print(f"  - SSL Mode: {db_config['SSL_MODE']}")
 
-print("\n✅ Envsh with shell scripts can:")
-print("   - Use variable interpolation: $VAR, ${VAR}")
-print("   - Perform calculations: $(($VAR + 1))")
-print("   - Execute commands: $(date), $(nproc)")
-print("   - Create dynamic configurations")
-print("   - Share common values between variables")
+print("\n🔧 MQTT Configuration Management:")
+print(f"  - Quality of Service: {mqtt_config['QOS']}")
+print(f"  - Keep Alive: {mqtt_config['KEEP_ALIVE']} seconds")
+print(f"  - Topic Prefix: {mqtt_config.get('TOPIC_PREFIX', 'Not set')}")
 
-print("\n=== Use Cases ===")
-print("🔧 Dynamic port allocation based on base port")
-print("🔧 Environment-specific database URLs")
-print("🔧 Configuration that adapts to system resources")
-print("🔧 Build-time variable injection")
-print("🔧 Complex service discovery URLs")
+print("\n🔧 Redis Configuration Management:")
+print(f"  - Connection Pool: {redis_config['POOL_SIZE']} connections")
+print(f"  - Database Index: {redis_config['DATABASE']}")
+print(f"  - Password Protected: {'Yes' if redis_config['PASSWORD'] else 'No'}")
+
+print("\n=== Why Configuration Structures Matter ===")
+print("❌ Standard .env files:")
+print("   DB_HOST=localhost")
+print("   DB_PORT=5432")
+print("   DB_USER=admin")
+print("   # Flat structure, no organization")
+
+print("\n✅ Envsh with Bash associative arrays:")
+print("   declare -A DB_CONFIG=(")
+print("       [HOST]='localhost'")
+print("       [PORT]='5432'")
+print("       [USER]='admin'")
+print("   )")
+print("   export_array_as_json DB_CONFIG")
+print("   # Structured configuration, easy to manage!")
+
+print("\n=== Advanced Use Cases ===")
+print("🔧 Multi-environment configuration profiles")
+print("🔧 Service discovery with structured endpoints")
+print("🔧 Connection pool management")
+print("🔧 Feature flags and service configurations")
+print("🔧 Microservices configuration templates")
 
 print("\n=== Demo completed successfully! ===")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ where = ["src"]
 [tool.setuptools.package-dir]
 "" = "src"
 
+[tool.setuptools.package-data]
+envsh = ["*.sh"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "envsh"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Python library for loading environment variables from shell scripts with type-safe reading capabilities"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/envsh/envsh-utils.sh
+++ b/src/envsh/envsh-utils.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# envsh-utils.sh - Utility functions for working with associative arrays
+# This file is automatically installed with the envsh Python package
+
+# Convert associative array to JSON string
+# Usage: _convert_array_to_json <array_name>
+_convert_array_to_json() {
+    local -n profile=$1
+    local json="{"
+    for key in "${!profile[@]}"; do
+        json+="\"$key\": \"${profile[$key]}\","
+    done
+    echo "${json%,}}"
+}
+
+# Export associative array as JSON variable
+# Usage: export_array_as_json <array_name> [json_var_name]
+export_array_as_json() {
+    local source_array_name="$1"
+    local destination_variable_name="${2:-${source_array_name}_JSON}"
+
+    if ! declare -p "$source_array_name" 2>/dev/null | grep -q 'declare -A'; then
+        echo "Error: Array '$source_array_name' is not declared!" >&2
+        return 1
+    fi
+
+    local json_value
+    json_value=$(_convert_array_to_json "$source_array_name")
+    eval "declare -g $destination_variable_name='$json_value'"
+    eval "export $destination_variable_name"
+}
+
+export -f export_array_as_json
+
+# Check if this script is being sourced (recommended usage)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo "Warning: This script should be sourced, not executed directly."
+    echo "Usage: source envsh-utils.sh"
+fi

--- a/tests/env.sh
+++ b/tests/env.sh
@@ -9,6 +9,13 @@ export TEST_STR="Hello, World!"
 export TEST_BASE_VALUE="base"
 export TEST_SPECIAL_CHARS="hello world, test@example.com"
 
+declare -A TEST_DICT=(
+    [key1]="value1"
+    [key2]=$TEST_STR
+    [key3]="value3"
+)
+export_array_as_json TEST_DICT 2>/dev/null || true
+
 # Variable interpolation in arrays - this is the key advantage!
 export TEST_INT_ARRAY="1,$TEST_INT,3,4,5"
 export TEST_STR_ARRAY="foo,$TEST_STR,baz"
@@ -20,6 +27,8 @@ export TEST_DYNAMIC_STRING="Generated at $(date +%H:%M)"
 
 export TEST_EMPTY_STR=""
 export TEST_EMPTY_ARRAY=""
+declare -A TEST_EMPTY_DICT=()
+export_array_as_json TEST_EMPTY_DICT 2>/dev/null || true
 export TEST_SINGLE_INT="42"
 export TEST_SINGLE_STR="single"
 export TEST_SPACES_ARRAY="  apple  , banana , cherry  "

--- a/tests/test_envsh.py
+++ b/tests/test_envsh.py
@@ -24,6 +24,11 @@ class TestEnvsh(unittest.TestCase):
         self.assertEqual(envsh.read_env('TEST_STR', str), 'Hello, World!')
         self.assertEqual(envsh.read_env('TEST_INT_ARRAY', list[int]), [1, 123, 3, 4, 5])
         self.assertEqual(envsh.read_env('TEST_STR_ARRAY', list[str]), ['foo', 'Hello', 'World!', 'baz'])
+        self.assertEqual(envsh.read_env('TEST_DICT_JSON', dict), {
+            "key1": "value1",
+            "key2": "Hello, World!",
+            "key3": "value3",
+        })
 
     def test_interpolation_and_calculation(self) -> None:
         """Test interpolation and calculations in environment variables."""
@@ -33,15 +38,18 @@ class TestEnvsh(unittest.TestCase):
         str_array = envsh.read_env('TEST_STR_ARRAY', list[str])
         mixed_array = envsh.read_env('TEST_MIXED_INTERPOLATION', list[str])
         calc_array = envsh.read_env('TEST_CALCULATED_ARRAY', list[int])
+        json_dict = envsh.read_env('TEST_DICT_JSON', dict)
         self.assertIn(base_int, int_array)
         self.assertIn(base_str.split(',')[0], str_array)
         self.assertTrue(any("base" in item for item in mixed_array))
         self.assertEqual(calc_array, [123, 133, 246])
+        self.assertEqual(json_dict.get("key2"), base_str)
 
     def test_empty_and_spaces(self) -> None:
         """Test handling of empty values and spaces."""
         self.assertEqual(envsh.read_env('TEST_EMPTY_STR', str), '')
         self.assertEqual(envsh.read_env('TEST_EMPTY_ARRAY', list[str]), [])
+        self.assertEqual(envsh.read_env('TEST_EMPTY_DICT_JSON', dict), {})
         self.assertEqual(envsh.read_env('TEST_SPACES_ARRAY', list[str]), ['apple', 'banana', 'cherry'])
 
     def test_errors(self) -> None:
@@ -55,7 +63,7 @@ class TestEnvsh(unittest.TestCase):
         with self.assertRaises(ValueError):
             envsh.read_env('TEST_INVALID_INT_ARRAY', list[int])
         with self.assertRaises(TypeError):
-            envsh.read_env('TEST_STR_ARRAY', dict) # type: ignore[arg-type]
+            envsh.read_env('TEST_STR_ARRAY', frozenset) # type: ignore[arg-type]
 
     def test_special_and_dynamic(self) -> None:
         """Test special characters and dynamic strings."""


### PR DESCRIPTION
### Added
- Bash associative arrays support via `envsh-utils.sh`
- `export_array_as_json` function for converting associative arrays to JSON
- Support for reading dictionary structures with `read_env(..., dict)` 
- Variable interpolation within associative array values
- Complex configuration profiles using structured data
- Enhanced shell utilities for better configuration management
- Examples demonstrating structured configuration usage

### Enhanced
- Shell environment loading now includes utility functions
- Improved documentation with structured configuration examples